### PR TITLE
Check if player ref exists before updating state

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,7 @@ export default class VideoPlayer extends Component {
       this.props.onProgress(event);
     }
     if (this.player) {
+      // check if ref exist first
       this.setState({
         progress: event.currentTime / (this.props.duration || this.state.duration),
       }); 


### PR DESCRIPTION
Problem: If the loop prop is set to true, I get a warning when unmounting the component. 
Warning: "setState(...): Can only update a mounted or mounting component...."
Solution: Check if player ref exists before updating progress state.